### PR TITLE
ci: fix lintstaged not properly format tsx and css

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "*.{json,md,js,jsx,ts,tsx}": "prettier --write",
+  "*.{json,md,css,scss,js,jsx,ts,tsx}": "prettier --write",
   Dockerfile: (absoluteFileNames) =>
     absoluteFileNames.map((absoluteFileName) => {
       const path = require("path");

--- a/apps/web/.lintstagedrc.js
+++ b/apps/web/.lintstagedrc.js
@@ -6,5 +6,6 @@ const buildEslintCommand = (filenames) =>
     .join(" --file ")}`;
 
 module.exports = {
-  "*.{js,jsx,ts,tsx}": [buildEslintCommand],
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand, "prettier --write"],
+  "*.{json,md,css,scss}": "prettier --write",
 };


### PR DESCRIPTION
## Short description
Allow lintstaged to properly format files with prettier

## Issue ticket number and link

## Additional information
Due to next.js eslint integration + custom-eslint-config's eslint config prettier, next lint --fix alone is not enough to format files.